### PR TITLE
python-tzdata 2025.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2023.3" %}
+{% set version = "2025.2" %}
 
 package:
   name: python-tzdata
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/tzdata/tzdata-{{ version }}.tar.gz
-  sha256: 11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a
+  sha256: b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8123](https://anaconda.atlassian.net/browse/PKG-8123)
- [Upstream repository](https://github.com/python/tzdata/tree/2025.2)
- [Upstream changelog/diff](https://github.com/python/tzdata/releases)

### Explanation of changes:

- Update version


[PKG-8123]: https://anaconda.atlassian.net/browse/PKG-8123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ